### PR TITLE
Fix test data path resolution

### DIFF
--- a/FusionFall-Mod.Tests/UnityCommandTests.cs
+++ b/FusionFall-Mod.Tests/UnityCommandTests.cs
@@ -27,7 +27,9 @@ public class UnityCommandTests
     [MemberData(nameof(Cases))]
     public async Task PackAndExtract(string caseFolder, string fileName)
     {
-        string baseDir = Path.Combine("test", caseFolder);
+        // определяем путь к каталогу тестовых данных относительно корня проекта
+        string rootDir = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        string baseDir = Path.Combine(rootDir, "test", caseFolder);
         string originalPath = Path.Combine(baseDir, fileName);
         string unpackedDir = Path.Combine(baseDir, fileName + "_unpacked");
         string workDir = Path.Combine(baseDir, "work");


### PR DESCRIPTION
## Summary
- compute absolute path to test data folder from project root

## Testing
- `dotnet build`
- `dotnet test` *(fails: SevenZip.DataErrorException, Различия)*

------
https://chatgpt.com/codex/tasks/task_e_68956c1a867083259e023abfb6b3fa4c