### PR TITLE
Remove uncompressed and raw extraction commands

### DIFF
--- a/FusionFall-Mod/Core/UnityPackageHelper.cs
+++ b/FusionFall-Mod/Core/UnityPackageHelper.cs
@@ -232,10 +232,10 @@ namespace FusionFall_Mod.Core
         /// <summary>
         /// Упаковка файлов в формат unity3d.
         /// </summary>
-        public static async Task PackAsync(List<FileEntry> fileEntries, string outputFile, bool compress, string flag)
+        public static async Task PackAsync(List<FileEntry> fileEntries, string outputFile, string flag)
         {
             byte[] headerData = await BuildHeaderData(fileEntries);
-            byte[] compressedData = compress ? LzmaHelper.CompressData(headerData) : headerData;
+            byte[] compressedData = LzmaHelper.CompressData(headerData);
             byte[] finalFile = BuildUnityWebFile(compressedData, headerData.Length, "fusion-2.x.x", "2.5.4b5", UnityHeader.MainHeaderSize);
             await File.WriteAllBytesAsync(outputFile, finalFile);
         }
@@ -243,10 +243,10 @@ namespace FusionFall_Mod.Core
         /// <summary>
         /// Упаковка файлов из папки.
         /// </summary>
-        public static async Task PackAsync(string folderPath, string outputFile, bool compress, string flag)
+        public static async Task PackAsync(string folderPath, string outputFile, string flag)
         {
             List<FileEntry> entries = CollectFileEntries(folderPath);
-            await PackAsync(entries, outputFile, compress, flag);
+            await PackAsync(entries, outputFile, flag);
         }
 
         /// <summary>
@@ -283,15 +283,5 @@ namespace FusionFall_Mod.Core
             }
         }
 
-        /// <summary>
-        /// Извлечение необработанного заголовка.
-        /// </summary>
-        public static async Task<byte[]> ExtractRawAsync(string inputFile)
-        {
-            byte[] fileContent = await File.ReadAllBytesAsync(inputFile);
-            byte[] compData = new byte[fileContent.Length - UnityHeader.MainHeaderSize];
-            Buffer.BlockCopy(fileContent, UnityHeader.MainHeaderSize, compData, 0, compData.Length);
-            return LzmaHelper.DecompressData(compData);
-        }
     }
 }

--- a/FusionFall-Mod/MainWindow.axaml
+++ b/FusionFall-Mod/MainWindow.axaml
@@ -17,9 +17,7 @@
         <!-- Основные кнопки и список файлов -->
         <StackPanel Grid.Row="1" Margin="0,10,0,0">
             <Button Content="Pack (.unity3d) [Compressed]" Margin="0,5" Command="{Binding PackCommand}"/>
-            <Button Content="Pack (.unity3d-uncompress) [Uncompressed]" Margin="0,5" Command="{Binding PackUncompressedCommand}"/>
             <Button Content="Extract Files" Margin="0,5" Command="{Binding ExtractCommand}"/>
-            <Button Content="Extract Raw Header" Margin="0,5" Command="{Binding ExtractRawCommand}"/>
             <ListBox ItemsSource="{Binding Files}" Margin="0,10" Height="150"/>
         </StackPanel>
     </Grid>

--- a/FusionFall-Mod/MainWindowViewModel.cs
+++ b/FusionFall-Mod/MainWindowViewModel.cs
@@ -25,10 +25,8 @@ namespace FusionFall_Mod
 
             Files = new ObservableCollection<string>();
 
-            PackCommand = new AsyncCommand(() => PackUnity3D(true));
-            PackUncompressedCommand = new AsyncCommand(() => PackUnity3D(false));
+            PackCommand = new AsyncCommand(PackUnity3D);
             ExtractCommand = new AsyncCommand(ExtractFiles);
-            ExtractRawCommand = new AsyncCommand(ExtractRawHeader);
         }
 
         public List<string> HeaderFlags { get; }
@@ -49,12 +47,10 @@ namespace FusionFall_Mod
         public ObservableCollection<string> Files { get; }
 
         public ICommand PackCommand { get; }
-        public ICommand PackUncompressedCommand { get; }
         public ICommand ExtractCommand { get; }
-        public ICommand ExtractRawCommand { get; }
 
         // Упаковка ресурсов в файл unity3d
-        private async Task PackUnity3D(bool compress)
+        private async Task PackUnity3D()
         {
             FilePickerSaveOptions sfo = new FilePickerSaveOptions
             {
@@ -99,7 +95,7 @@ namespace FusionFall_Mod
 
             try
             {
-                await UnityPackageHelper.PackAsync(fileEntries, outputFilename, compress, SelectedFlag);
+                await UnityPackageHelper.PackAsync(fileEntries, outputFilename, SelectedFlag);
                 await MessageBoxManager.GetMessageBoxStandard("Success", "Packing completed successfully.").ShowAsync();
             }
             catch (Exception ex)
@@ -147,26 +143,6 @@ namespace FusionFall_Mod
             }
         }
 
-        // Извлечение необработанного заголовка
-        private async Task ExtractRawHeader()
-        {
-            string? inputFilename = await ShowUnityFileDialog();
-            if (inputFilename == null)
-                return;
-            string? inputDir = Path.GetDirectoryName(inputFilename);
-            string outputFile = Path.Combine(inputDir!, "uncompress_file");
-
-            try
-            {
-                byte[] decomData = await UnityPackageHelper.ExtractRawAsync(inputFilename);
-                await File.WriteAllBytesAsync(outputFile, decomData);
-                await MessageBoxManager.GetMessageBoxStandard("Success", "Raw header extracted successfully.").ShowAsync();
-            }
-            catch (Exception ex)
-            {
-                await MessageBoxManager.GetMessageBoxStandard("Error", $"Extraction failed:\n{ex.Message}").ShowAsync();
-            }
-        }
     }
 }
 


### PR DESCRIPTION
## Summary
- remove UI buttons for uncompressed pack and raw header extraction
- drop PackUncompressedCommand and ExtractRawCommand logic
- simplify packing helper to always compress

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68974d78fce883258d88ed1ea7a8cc35