### PR TITLE
Persist header metadata via JSON

### DIFF
--- a/FusionFall-Mod/HeaderInfo.cs
+++ b/FusionFall-Mod/HeaderInfo.cs
@@ -1,0 +1,23 @@
+namespace FusionFall_Mod.Models
+{
+    /// <summary>
+    /// Сведения о заголовке Unity-файла.
+    /// </summary>
+    public class HeaderInfo
+    {
+        /// <summary>
+        /// Основная (мажорная) версия.
+        /// </summary>
+        public byte MajorVersion { get; set; }
+
+        /// <summary>
+        /// Дополнительная информация о версии.
+        /// </summary>
+        public string VersionInfo { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Информация о сборке.
+        /// </summary>
+        public string BuildInfo { get; set; } = string.Empty;
+    }
+}

--- a/FusionFall-Mod/MainWindowViewModel.cs
+++ b/FusionFall-Mod/MainWindowViewModel.cs
@@ -95,7 +95,7 @@ namespace FusionFall_Mod
 
             try
             {
-                await UnityPackageHelper.PackAsync(fileEntries, outputFilename, SelectedFlag);
+                await UnityPackageHelper.PackAsync(folderPath, outputFilename, SelectedFlag);
                 await MessageBoxManager.GetMessageBoxStandard("Success", "Packing completed successfully.").ShowAsync();
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
- add `HeaderInfo` model to serialize header details
- save header metadata to `header.json` when extracting
- load `header.json` to apply version fields during packing

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68976343b55c832582898bd4b7dc3bca