### PR TITLE
Refactor Unity header info

### DIFF
--- a/FusionFall-Mod/Core/UnityPackageHelper.cs
+++ b/FusionFall-Mod/Core/UnityPackageHelper.cs
@@ -142,11 +142,11 @@ namespace FusionFall_Mod.Core
             binaryWriter.Write(new byte[4]);
 
             // версия
-            binaryWriter.Write(header.MajorVersion);
+            binaryWriter.Write(header.Info.MajorVersion);
 
             // строки версий
-            WriteCString(binaryWriter, header.VersionInfo);
-            WriteCString(binaryWriter, header.BuildInfo);
+            WriteCString(binaryWriter, header.Info.VersionInfo);
+            WriteCString(binaryWriter, header.Info.BuildInfo);
 
             // поле SIZE (будет перезаписано после вычисления last_offset)
             long sizePosition = outputStream.Position;
@@ -270,9 +270,9 @@ namespace FusionFall_Mod.Core
                     HeaderInfo? info = JsonSerializer.Deserialize<HeaderInfo>(await File.ReadAllTextAsync(jsonPath));
                     if (info != null)
                     {
-                        header.MajorVersion = info.MajorVersion;
-                        header.VersionInfo = info.VersionInfo;
-                        header.BuildInfo = info.BuildInfo;
+                        header.Info.MajorVersion = info.MajorVersion;
+                        header.Info.VersionInfo = info.VersionInfo;
+                        header.Info.BuildInfo = info.BuildInfo;
                     }
                 }
                 catch

--- a/FusionFall-Mod/UnityHeader.cs
+++ b/FusionFall-Mod/UnityHeader.cs
@@ -19,19 +19,14 @@ namespace FusionFall_Mod.Models
         public string FlagFile { get; }
 
         /// <summary>
-        /// Основная (мажорная) версия.
+        /// Информация о заголовке файла.
         /// </summary>
-        public byte MajorVersion { get; set; } = 2;
-
-        /// <summary>
-        /// Дополнительная информация о версии.
-        /// </summary>
-        public string VersionInfo { get; set; } = "fusion-2.x.x";
-
-        /// <summary>
-        /// Инфо о сборке.
-        /// </summary>
-        public string BuildInfo { get; set; } = "2.5.4b5";
+        public HeaderInfo Info { get; } = new HeaderInfo
+        {
+            MajorVersion = 2,
+            VersionInfo = "fusion-2.x.x",
+            BuildInfo = "2.5.4b5"
+        };
 
         /// <summary>
         /// Полный размер файла.


### PR DESCRIPTION
## Summary
- deduplicate version fields by embedding `HeaderInfo` into `UnityHeader`
- update Unity package helper to use `HeaderInfo`

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_689768910adc83258d50ae55ab7c350a