### PR TITLE
Ensure JSON info file saved during extraction

### DIFF
--- a/FusionFall-Mod/Core/UnityPackageHelper.cs
+++ b/FusionFall-Mod/Core/UnityPackageHelper.cs
@@ -308,6 +308,8 @@ namespace FusionFall_Mod.Core
                 VersionInfo = versionInfo,
                 BuildInfo = buildInfo
             };
+            // создание папки для сохранения JSON
+            Directory.CreateDirectory(outputDir);
             string jsonText = JsonSerializer.Serialize(info, new JsonSerializerOptions { WriteIndented = true });
             await File.WriteAllTextAsync(Path.Combine(outputDir, "header.json"), jsonText);
 


### PR DESCRIPTION
## Summary
- Create output directory before writing header.json when extracting packages

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68976b81ec38832589cfbf642025c90b