### PR TITLE
Name extracted folder after source file

### DIFF
--- a/FusionFall-Mod/MainWindowViewModel.cs
+++ b/FusionFall-Mod/MainWindowViewModel.cs
@@ -129,7 +129,9 @@ namespace FusionFall_Mod
             if (inputFilename == null)
                 return;
             string? inputDir = Path.GetDirectoryName(inputFilename);
-            string outputDir = Path.Combine(inputDir!, "uncompressfiles");
+            string fileBase = Path.GetFileNameWithoutExtension(inputFilename);
+            string outputDir = Path.Combine(inputDir!, $"{fileBase}_unpacked");
+            // Формирование пути распакованной папки
             Directory.CreateDirectory(outputDir);
 
             try


### PR DESCRIPTION
## Summary
- name extraction output folder after the source archive

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689776fd9c78832590f0e01278aa06bc