### PR TITLE
Упростить интерфейс упаковки и добавить консоль логов

### DIFF
--- a/FusionFall-Mod/Core/UnityPackageHelper.cs
+++ b/FusionFall-Mod/Core/UnityPackageHelper.cs
@@ -302,6 +302,10 @@ namespace FusionFall_Mod.Core
 
             // 1) Заголовок
             string flag = Encoding.ASCII.GetString(reader.ReadBytes(8)); // "UnityWeb" или "streamed"
+            if (flag != UnityHeader.DefaultFlag && flag != UnityHeader.RetroFlag)
+            {
+                throw new InvalidDataException("Неизвестный заголовок.");
+            }
             _ = reader.ReadUInt32();                                     // u32 0
             byte major = reader.ReadByte();                              // версия формата (2 или 3)
             string versionInfo = ReadCString(reader);

--- a/FusionFall-Mod/MainWindow.axaml
+++ b/FusionFall-Mod/MainWindow.axaml
@@ -7,18 +7,12 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
-        <!-- Панель выбора версии заголовка -->
-        <StackPanel Orientation="Horizontal">
-            <TextBlock Text="Header Flag:" VerticalAlignment="Center"/>
-            <ComboBox Width="120" Margin="5,0"
-                      ItemsSource="{Binding HeaderFlags}"
-                      SelectedItem="{Binding SelectedFlag}"/>
-        </StackPanel>
-        <!-- Основные кнопки и список файлов -->
-        <StackPanel Grid.Row="1" Margin="0,10,0,0">
+        <!-- Кнопки и консоль вывода -->
+        <StackPanel>
             <Button Content="Pack (.unity3d) [Compressed]" Margin="0,5" Command="{Binding PackCommand}"/>
             <Button Content="Extract Files" Margin="0,5" Command="{Binding ExtractCommand}"/>
-            <ListBox ItemsSource="{Binding Files}" Margin="0,10" Height="150"/>
         </StackPanel>
+        <TextBox Grid.Row="1" Margin="0,10,0,0" Text="{Binding ConsoleText}" IsReadOnly="True"
+                 AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
     </Grid>
 </Window>


### PR DESCRIPTION
## Summary
- Удалён выбор заголовка и список файлов из интерфейса, добавлена консоль вывода
- ViewModel логирует процессы упаковки и распаковки, всегда используя заголовок UnityWeb
- Распаковщик проверяет первые байты на `UnityWeb` или `streamed`

## Testing
- `dotnet build` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689786e97d1083258c058608d47f4859