### PR TITLE
Replace assets packer

### DIFF
--- a/FusionFall-Mod/Core/RawAssetsHelper.cs
+++ b/FusionFall-Mod/Core/RawAssetsHelper.cs
@@ -1,254 +1,26 @@
-using System;
-using System.Buffers.Binary;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Text.Json;
 
 namespace FusionFall_Mod.Core
 {
     /// <summary>
-    /// Утилиты для распаковки и упаковки файлов sharedassets*.assets.
+    /// Обёртки для распаковки и сборки файлов sharedassets*.assets.
     /// </summary>
     public static class RawAssetsHelper
     {
-        // --- Минимальные утилиты для (де)сериализации ---
-        private static class BE
-        {
-            public static uint ReadU32(ReadOnlySpan<byte> s, int off) => BinaryPrimitives.ReadUInt32BigEndian(s.Slice(off, 4));
-            public static void WriteU32(Span<byte> s, int off, uint v) => BinaryPrimitives.WriteUInt32BigEndian(s.Slice(off, 4), v);
-        }
-
-        private static class LE
-        {
-            public static int ReadS32(ReadOnlySpan<byte> s, int off) => BinaryPrimitives.ReadInt32LittleEndian(s.Slice(off, 4));
-            public static uint ReadU32(ReadOnlySpan<byte> s, int off) => BinaryPrimitives.ReadUInt32LittleEndian(s.Slice(off, 4));
-            public static long ReadS64(ReadOnlySpan<byte> s, int off) => BinaryPrimitives.ReadInt64LittleEndian(s.Slice(off, 8));
-            public static void WriteS32(Span<byte> s, int off, int v) => BinaryPrimitives.WriteInt32LittleEndian(s.Slice(off, 4), v);
-            public static void WriteU32(Span<byte> s, int off, uint v) => BinaryPrimitives.WriteUInt32LittleEndian(s.Slice(off, 4), v);
-        }
-
-        // --- Модель манифеста для упаковки ---
-        private record RawEntry(int PathID, uint Offset, uint Size, int TypeId, byte[] Extra);
-
-        private record Manifest(
-            string UnityVersion,
-            int TargetPlatform,
-            int HeaderVersion,
-            uint MetaDataOffset,
-            uint FileSize,
-            byte Endianness,
-            int EntrySize,
-            string MetaPrefixBase64,
-            string MetaSuffixBase64,
-            List<RawEntry> Entries);
-
         /// <summary>
-        /// Распаковка файла .assets в указанную папку.
+        /// Распаковать файл .assets в указанную папку.
         /// </summary>
         public static void Unpack(string inputPath, string outDir)
         {
-            Directory.CreateDirectory(outDir);
-            var bytes = File.ReadAllBytes(inputPath);
-            var ro = new ReadOnlySpan<byte>(bytes);
-
-            // ---- Прочитать заголовок (big-endian) ----
-            uint metaSize = BE.ReadU32(ro, 0);
-            uint fileSize = BE.ReadU32(ro, 4);
-            int headerVer = (int)BE.ReadU32(ro, 8);
-            uint dataOffset = BE.ReadU32(ro, 12);
-            byte endian = ro[16]; // 0 = little, 1 = big (метаданные)
-            int p = 20;
-
-            // UnityVersion (ASCIIZ)
-            string unityVer = ReadCString(ro, ref p);
-            int targetPlatform = LE.ReadS32(ro, p); p += 4;
-
-            // Поиск начала таблицы объектов
-            int metaStart = p;
-            int metaEnd = (int)dataOffset;
-            var (tableOff, entrySize, n) = FindObjectTable(ro, metaStart, metaEnd, dataOffset, fileSize);
-            int tableBytesStart = tableOff + 4;
-            int tableBytesEnd = tableBytesStart + n * entrySize;
-
-            byte[] metaPrefix = ro.Slice(0, tableOff).ToArray();
-            byte[] metaSuffix = ro.Slice(tableBytesEnd, metaEnd - tableBytesEnd).ToArray();
-
-            var entries = new List<RawEntry>(n);
-            for (int i = 0; i < n; i++)
-            {
-                int epos = tableBytesStart + i * entrySize;
-                int pathId = LE.ReadS32(ro, epos + 0);
-                uint off = LE.ReadU32(ro, epos + 4);
-                uint size = LE.ReadU32(ro, epos + 8);
-                int typeId = LE.ReadS32(ro, epos + 12);
-                byte[] extra = entrySize > 16 ? ro.Slice(epos + 16, entrySize - 16).ToArray() : Array.Empty<byte>();
-                entries.Add(new RawEntry(pathId, off, size, typeId, extra));
-            }
-
-            // Пишем объекты
-            var objDir = Path.Combine(outDir, "Objects");
-            Directory.CreateDirectory(objDir);
-            foreach (var e in entries)
-            {
-                var obj = ro.Slice((int)e.Offset, checked((int)e.Size)).ToArray();
-                File.WriteAllBytes(Path.Combine(objDir, $"{e.PathID}.bin"), obj);
-            }
-
-            // Пишем манифест
-            var manifest = new Manifest(
-                UnityVersion: unityVer,
-                TargetPlatform: targetPlatform,
-                HeaderVersion: headerVer,
-                MetaDataOffset: dataOffset,
-                FileSize: fileSize,
-                Endianness: endian,
-                EntrySize: entrySize,
-                MetaPrefixBase64: Convert.ToBase64String(metaPrefix),
-                MetaSuffixBase64: Convert.ToBase64String(metaSuffix),
-                Entries: entries
-            );
-            var manifestJson = JsonSerializer.Serialize(manifest, new JsonSerializerOptions { WriteIndented = true });
-            File.WriteAllText(Path.Combine(outDir, "out.manifest.json"), manifestJson, new UTF8Encoding(false));
-
-            Console.WriteLine($"Unpacked {n} objects to {objDir}");
+            UnityAssetsV6Packer.UnpackAssetsV6(inputPath, outDir);
         }
 
         /// <summary>
-        /// Упаковка распакованных объектов обратно в .assets.
+        /// Собрать файл .assets из распакованной структуры.
         /// </summary>
-        public static void Pack(string originalAssets, string unpackDir, string outAssets)
+        public static void Pack(string unpackDir, string outAssets)
         {
-            var orig = File.ReadAllBytes(originalAssets);
-
-            var manifestPath = Path.Combine(unpackDir, "out.manifest.json");
-            if (!File.Exists(manifestPath))
-                throw new FileNotFoundException("Не найден манифест out.manifest.json в папке распаковки.", manifestPath);
-
-            var manifest = JsonSerializer.Deserialize<Manifest>(File.ReadAllText(manifestPath))
-                           ?? throw new Exception("Не удалось разобрать manifest JSON.");
-
-            var metaPrefix = Convert.FromBase64String(manifest.MetaPrefixBase64);
-            var metaSuffix = Convert.FromBase64String(manifest.MetaSuffixBase64);
-
-            int entrySize = manifest.EntrySize;
-            uint dataOffsetNew = (uint)(metaPrefix.Length + 4 + manifest.Entries.Count * entrySize + metaSuffix.Length);
-
-            using var fsOut = new FileStream(outAssets, FileMode.Create, FileAccess.Write, FileShare.None);
-            using var msMeta = new MemoryStream();
-            msMeta.Write(metaPrefix, 0, metaPrefix.Length);
-
-            Span<byte> tmp4 = stackalloc byte[4];
-            LE.WriteS32(tmp4, 0, manifest.Entries.Count);
-            msMeta.Write(tmp4);
-
-            var newEntries = new List<RawEntry>(manifest.Entries.Count);
-            long cursor = dataOffsetNew;
-            const int ALIGN = 4;
-            foreach (var e in manifest.Entries)
-            {
-                var customPath = Path.Combine(unpackDir, "Objects", $"{e.PathID}.bin");
-                byte[] payload = File.Exists(customPath)
-                    ? File.ReadAllBytes(customPath)
-                    : new ReadOnlySpan<byte>(orig, (int)e.Offset, (int)e.Size).ToArray();
-
-                long pad = (ALIGN - (cursor % ALIGN)) % ALIGN;
-                cursor += pad;
-
-                var ne = new RawEntry(e.PathID, (uint)cursor, (uint)payload.Length, e.TypeId, e.Extra);
-                newEntries.Add(ne);
-                cursor += payload.Length;
-            }
-
-            foreach (var e in newEntries)
-            {
-                Span<byte> row = stackalloc byte[entrySize];
-                LE.WriteS32(row, 0, e.PathID);
-                LE.WriteU32(row, 4, e.Offset);
-                LE.WriteU32(row, 8, e.Size);
-                LE.WriteS32(row, 12, e.TypeId);
-                if (entrySize > 16)
-                    e.Extra.CopyTo(row.Slice(16));
-                msMeta.Write(row);
-            }
-            msMeta.Write(metaSuffix, 0, metaSuffix.Length);
-
-            byte[] metaAll = msMeta.ToArray();
-            uint metaSizeNew = (uint)metaAll.Length;
-            byte[] header = new byte[20];
-            Array.Copy(orig, 0, header, 0, 20);
-            BE.WriteU32(header, 0, metaSizeNew);
-            BE.WriteU32(header, 8, (uint)manifest.HeaderVersion);
-            BE.WriteU32(header, 12, metaSizeNew);
-
-            fsOut.Write(metaAll, 0, metaAll.Length);
-
-            long dataStartPos = fsOut.Position;
-            foreach (var e in newEntries)
-            {
-                long current = fsOut.Position;
-                long pad = (ALIGN - (current % ALIGN)) % ALIGN;
-                if (pad > 0) fsOut.Write(new byte[pad], 0, (int)pad);
-
-                byte[] payload;
-                var customPath = Path.Combine(unpackDir, "Objects", $"{e.PathID}.bin");
-                if (File.Exists(customPath)) payload = File.ReadAllBytes(customPath);
-                else payload = new ReadOnlySpan<byte>(orig, (int)manifest.Entries.First(x => x.PathID == e.PathID).Offset,
-                                                       (int)manifest.Entries.First(x => x.PathID == e.PathID).Size).ToArray();
-                fsOut.Write(payload, 0, payload.Length);
-            }
-
-            long finalSize = fsOut.Length;
-            fsOut.Position = 4;
-            Span<byte> be4 = stackalloc byte[4];
-            BE.WriteU32(be4, 0, (uint)finalSize);
-            fsOut.Write(be4);
-            fsOut.Flush();
-
-            Console.WriteLine($"Packed {newEntries.Count} objects -> {outAssets}");
-        }
-
-        // --- Вспомогательные методы ---
-        private static (int tableOff, int entrySize, int count) FindObjectTable(ReadOnlySpan<byte> data, int searchStart, int searchEnd, uint dataOffset, uint fileSize)
-        {
-            for (int s = searchStart; s <= searchEnd - 4; s++)
-            {
-                int n = LE.ReadS32(data, s);
-                if (n <= 0 || n > 1_000_000) continue;
-
-                foreach (int entrySize in new[] { 16, 20, 24 })
-                {
-                    long endPos = s + 4L + (long)n * entrySize;
-                    if (endPos > searchEnd) continue;
-
-                    bool ok = true;
-                    int checks = Math.Min(n, 64);
-                    for (int i = 0; i < checks; i++)
-                    {
-                        int epos = s + 4 + i * entrySize;
-                        uint off = LE.ReadU32(data, epos + 4);
-                        uint sz = LE.ReadU32(data, epos + 8);
-                        if (!(off >= dataOffset && off + sz <= fileSize && sz > 0))
-                        {
-                            ok = false;
-                            break;
-                        }
-                    }
-                    if (ok) return (s, entrySize, n);
-                }
-            }
-            throw new Exception("Не удалось найти таблицу объектов в метаданных.");
-        }
-
-        private static string ReadCString(ReadOnlySpan<byte> src, ref int pos)
-        {
-            int end = pos;
-            while (end < src.Length && src[end] != 0) end++;
-            var s = Encoding.UTF8.GetString(src.Slice(pos, end - pos));
-            pos = end + 1;
-            return s;
+            UnityAssetsV6Packer.BuildAssetsV6(unpackDir, outAssets);
         }
     }
 }
-

--- a/FusionFall-Mod/Core/UnityAssetsV6Packer.cs
+++ b/FusionFall-Mod/Core/UnityAssetsV6Packer.cs
@@ -1,0 +1,359 @@
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+
+namespace FusionFall_Mod.Core
+{
+    /// <summary>
+    /// Утилиты для распаковки и сборки Unity assets версии 6.
+    /// </summary>
+    public static class UnityAssetsV6Packer
+    {
+        // ---- Публичные API ----
+
+        public static void UnpackAssetsV6(string assetsPath, string outDir)
+        {
+            using var fs = File.OpenRead(assetsPath);
+            using var br = new BinaryReader(fs);
+
+            var hdr = ReadHeaderV6(br);
+            if (hdr.Version != 6)
+                throw new NotSupportedException($"SerializedFile version {hdr.Version} != 6");
+
+            var dataBase = hdr.DataOffset != 0 ? hdr.DataOffset : hdr.MetaSize;
+            if (dataBase <= 0 || dataBase > fs.Length)
+                throw new InvalidDataException("Bad dataBase");
+
+            fs.Position = 0;
+            var metadata = br.ReadBytes((int)dataBase);
+
+            var table = FindObjectTable(metadata, (long)fs.Length, (int)dataBase)
+                       ?? throw new InvalidDataException("Object table not found.");
+
+            Directory.CreateDirectory(outDir);
+            var metaPath = Path.Combine(outDir, "metadata.bin");
+            var objDir = Path.Combine(outDir, "objects");
+            Directory.CreateDirectory(objDir);
+            File.WriteAllBytes(metaPath, metadata);
+
+            var entries = new List<ObjectEntry>();
+            for (int i = 0; i < table.Count; i++)
+            {
+                var e = table[i];
+                var abs = dataBase + (long)e.OffsetRel;
+                if (abs < 0 || abs + e.Size > fs.Length)
+                    throw new InvalidDataException($"Entry {i}: bad data range");
+
+                fs.Position = abs;
+                var data = br.ReadBytes((int)e.Size);
+                var objName = $"{i:D5}__pid-{e.PathId}__typ-{e.TypeIndex}.bin";
+                File.WriteAllBytes(Path.Combine(objDir, objName), data);
+
+                entries.Add(e);
+            }
+
+            var manifest = new Manifest
+            {
+                Version = (int)hdr.Version,
+                MetaSize = (int)hdr.MetaSize,
+                FileSize = (long)hdr.FileSize,
+                DataBase = (int)dataBase,
+                TableOffset = table.TableOffset,
+                EntrySize = table.EntrySize,
+                PathIdIs64 = table.PathIdIs64,
+                Count = table.Count,
+                Entries = entries
+            };
+            File.WriteAllText(Path.Combine(outDir, "manifest.json"),
+                JsonSerializer.Serialize(manifest, new JsonSerializerOptions { WriteIndented = true }));
+        }
+
+        // ---- Внутренняя кухня ----
+
+        private static void Align4(BinaryWriter bw)
+        {
+            long pad = (4 - (bw.BaseStream.Position & 3)) & 3;
+            if (pad > 0) bw.Write(new byte[pad]);
+        }
+
+        private static HeaderV6 ReadHeaderV6(BinaryReader br)
+        {
+            br.BaseStream.Position = 0;
+            var metaSize = ReadBE32(br);
+            var fileSize = ReadBE32(br);
+            var version = ReadBE32(br);
+            var dataOff = ReadBE32(br);
+            var endianTag = ReadBE32(br);
+            return new HeaderV6
+            {
+                MetaSize = metaSize,
+                FileSize = fileSize,
+                Version = version,
+                DataOffset = dataOff,
+                EndianTag = endianTag
+            };
+        }
+
+        private static uint ReadBE32(BinaryReader br)
+        {
+            Span<byte> b = stackalloc byte[4];
+            br.Read(b);
+            return BinaryPrimitives.ReadUInt32BigEndian(b);
+        }
+
+        private static ObjectTable? FindObjectTable(byte[] metadata, long fileSize, int dataBase)
+        {
+            int start = 20;
+            int limit = Math.Min(metadata.Length, dataBase);
+            int bestCount = 0;
+            ObjectTable? best = null;
+
+            for (int pos = start; pos + 4 < limit; pos++)
+            {
+                int count = BitConverter.ToInt32(metadata, pos);
+                if (count <= 0 || count > 200000) continue;
+
+                foreach (var scheme in new[] { ("le64", 20), ("le32", 16) })
+                {
+                    bool ok = true;
+                    int recSize = scheme.Item2;
+                    long cursor = pos + 4;
+
+                    for (int i = 0; i < count; i++)
+                    {
+                        long basePos = cursor + i * recSize;
+                        if (basePos + recSize > limit) { ok = false; break; }
+
+                        long pathId;
+                        int offRel, size, typeIndex;
+                        if (scheme.Item1 == "le64")
+                        {
+                            pathId = BitConverter.ToInt64(metadata, (int)basePos + 0);
+                            offRel = BitConverter.ToInt32(metadata, (int)basePos + 8);
+                            size = BitConverter.ToInt32(metadata, (int)basePos + 12);
+                            typeIndex = BitConverter.ToInt32(metadata, (int)basePos + 16);
+                        }
+                        else
+                        {
+                            pathId = BitConverter.ToInt32(metadata, (int)basePos + 0);
+                            offRel = BitConverter.ToInt32(metadata, (int)basePos + 4);
+                            size = BitConverter.ToInt32(metadata, (int)basePos + 8);
+                            typeIndex = BitConverter.ToInt32(metadata, (int)basePos + 12);
+                        }
+
+                        if (size <= 0) { ok = false; break; }
+                        long abs = dataBase + (uint)offRel;
+                        if (abs <= 0 || abs + (uint)size > fileSize) { ok = false; break; }
+                        if (typeIndex < 0 || typeIndex > 4096) { ok = false; break; }
+                    }
+
+                    if (ok && count > bestCount)
+                    {
+                        var list = new List<ObjectEntry>(count);
+                        long basePos = pos + 4;
+                        for (int i = 0; i < count; i++)
+                        {
+                            long p = basePos + i * recSize;
+                            long pathId;
+                            int offRel, size, typeIndex;
+                            if (scheme.Item1 == "le64")
+                            {
+                                pathId = BitConverter.ToInt64(metadata, (int)p + 0);
+                                offRel = BitConverter.ToInt32(metadata, (int)p + 8);
+                                size = BitConverter.ToInt32(metadata, (int)p + 12);
+                                typeIndex = BitConverter.ToInt32(metadata, (int)p + 16);
+                            }
+                            else
+                            {
+                                pathId = BitConverter.ToInt32(metadata, (int)p + 0);
+                                offRel = BitConverter.ToInt32(metadata, (int)p + 4);
+                                size = BitConverter.ToInt32(metadata, (int)p + 8);
+                                typeIndex = BitConverter.ToInt32(metadata, (int)p + 12);
+                            }
+                            list.Add(new ObjectEntry
+                            {
+                                PathId = pathId,
+                                OffsetRel = (uint)offRel,
+                                Size = (uint)size,
+                                TypeIndex = typeIndex
+                            });
+                        }
+
+                        best = new ObjectTable
+                        {
+                            TableOffset = pos,
+                            PathIdIs64 = scheme.Item1 == "le64",
+                            EntrySize = recSize,
+                            Count = count,
+                            Entries = list
+                        };
+                        bestCount = count;
+                    }
+                }
+            }
+            return best;
+        }
+
+        // ---- DTOs ----
+        private struct HeaderV6
+        {
+            public uint MetaSize;
+            public uint FileSize;
+            public uint Version;
+            public uint DataOffset;
+            public uint EndianTag;
+        }
+
+        private class ObjectEntry
+        {
+            public long PathId { get; set; }
+            public uint OffsetRel { get; set; }
+            public uint Size { get; set; }
+            public int TypeIndex { get; set; }
+        }
+
+        private class ObjectTable
+        {
+            public int TableOffset { get; set; }
+            public bool PathIdIs64 { get; set; }
+            public int EntrySize { get; set; }
+            public int Count { get; set; }
+            public List<ObjectEntry> Entries { get; set; } = new();
+            public ObjectEntry this[int i] => Entries[i];
+        }
+
+        private class Manifest
+        {
+            public int Version { get; set; }
+            public int MetaSize { get; set; }
+            public long FileSize { get; set; }
+            public int DataBase { get; set; }
+            public int TableOffset { get; set; }
+            public int EntrySize { get; set; }
+            public bool PathIdIs64 { get; set; }
+            public int Count { get; set; }
+            public List<ObjectEntry> Entries { get; set; } = new();
+        }
+
+        // --- Публичный API для сборки ---
+        public static void BuildAssetsV6(string inDir, string outAssetsPath)
+        {
+            var manifestPath = Path.Combine(inDir, "manifest.json");
+            var metaPath = Path.Combine(inDir, "metadata.bin");
+            var objDir = Path.Combine(inDir, "objects");
+
+            var manifest = JsonSerializer.Deserialize<Manifest>(File.ReadAllText(manifestPath))
+                           ?? throw new InvalidDataException("manifest.json invalid");
+
+            var metaBytesFull = File.ReadAllBytes(metaPath);
+            byte[] metaCore;
+            if (metaBytesFull.Length == manifest.MetaSize) metaCore = metaBytesFull;
+            else if (metaBytesFull.Length == manifest.MetaSize + 20) metaCore = metaBytesFull.AsSpan(20, manifest.MetaSize).ToArray();
+            else if (metaBytesFull.Length > manifest.MetaSize) metaCore = metaBytesFull.AsSpan(metaBytesFull.Length - manifest.MetaSize, manifest.MetaSize).ToArray();
+            else throw new InvalidDataException($"metadata.bin size {metaBytesFull.Length} != MetaSize {manifest.MetaSize}");
+
+            var tbl = FindObjectTableInMeta(metaCore, manifest.Count)
+                      ?? throw new InvalidDataException("Object table not found in metadata.bin");
+
+            var files = Directory.GetFiles(objDir, "*.bin").OrderBy(p => p).ToArray();
+            if (files.Length != manifest.Count)
+                throw new InvalidDataException($"objects count mismatch: {files.Length} vs {manifest.Count}");
+
+            using var fs = File.Create(outAssetsPath);
+            using var bw = new BinaryWriter(fs);
+
+            bw.Write(new byte[20]);
+            bw.Write(metaCore);
+            long dataBase = 20 + metaCore.Length;
+
+            var newOffsets = new (long PathId, uint OffRel, uint Size)[manifest.Count];
+            for (int i = 0; i < manifest.Count; i++)
+            {
+                Align4(bw);
+                uint rel = (uint)(fs.Position - dataBase);
+
+                var bytes = File.ReadAllBytes(files[i]);
+                bw.Write(bytes);
+
+                newOffsets[i] = (manifest.Entries[i].PathId, rel, (uint)bytes.Length);
+            }
+
+            long tableAbsOffset = 20 + tbl.TableOffset;
+            fs.Position = tableAbsOffset;
+            Span<byte> buf = stackalloc byte[8];
+
+            BinaryPrimitives.WriteInt32LittleEndian(buf[..4], manifest.Count);
+            bw.Write(buf[..4]);
+
+            for (int i = 0; i < manifest.Count; i++)
+            {
+                var m = manifest.Entries[i];
+                var p = newOffsets[i];
+
+                if (tbl.PathIdIs64)
+                {
+                    BinaryPrimitives.WriteInt64LittleEndian(buf[..8], p.PathId);
+                    bw.Write(buf[..8]);
+                }
+                else
+                {
+                    BinaryPrimitives.WriteInt32LittleEndian(buf[..4], checked((int)p.PathId));
+                    bw.Write(buf[..4]);
+                }
+
+                BinaryPrimitives.WriteUInt32LittleEndian(buf[..4], p.OffRel); bw.Write(buf[..4]);
+                BinaryPrimitives.WriteUInt32LittleEndian(buf[..4], p.Size); bw.Write(buf[..4]);
+                BinaryPrimitives.WriteInt32LittleEndian(buf[..4], m.TypeIndex); bw.Write(buf[..4]);
+            }
+
+            long fileSize = fs.Length;
+            fs.Position = 0;
+            Span<byte> head = stackalloc byte[20];
+            BinaryPrimitives.WriteUInt32BigEndian(head[..4], (uint)metaCore.Length);
+            BinaryPrimitives.WriteUInt32BigEndian(head.Slice(4, 4), (uint)fileSize);
+            BinaryPrimitives.WriteUInt32BigEndian(head.Slice(8, 4), 6);
+            BinaryPrimitives.WriteUInt32BigEndian(head.Slice(12, 4), 0);
+            BinaryPrimitives.WriteUInt32BigEndian(head.Slice(16, 4), 0);
+            bw.Write(head);
+        }
+
+        private static ObjectTable? FindObjectTableInMeta(byte[] metaCore, int expectedCount)
+        {
+            int start = 0;
+            int limit = metaCore.Length;
+            ObjectTable? best = null;
+
+            for (int pos = start; pos + 4 <= limit - 16; pos++)
+            {
+                int count = BitConverter.ToInt32(metaCore, pos);
+                if (count <= 0 || count > 200000) continue;
+                if (expectedCount > 0 && count != expectedCount) continue;
+
+                foreach (var scheme in new[] { ("le64", 20), ("le32", 16) })
+                {
+                    bool ok = true;
+                    int recSize = scheme.Item2;
+
+                    long blockEnd = pos + 4L + (long)count * recSize;
+                    if (blockEnd > limit) { ok = false; }
+
+                    if (ok)
+                    {
+                        best = new ObjectTable
+                        {
+                            TableOffset = pos,
+                            PathIdIs64 = scheme.Item1 == "le64",
+                            EntrySize = recSize,
+                            Count = count
+                        };
+                        return best;
+                    }
+                }
+            }
+            return best;
+        }
+    }
+}

--- a/FusionFall-Mod/MainWindowViewModel.cs
+++ b/FusionFall-Mod/MainWindowViewModel.cs
@@ -157,10 +157,6 @@ namespace FusionFall_Mod
         // Упаковка файла sharedassets
         private async Task PackAssets()
         {
-            string? original = await ShowAssetsFileDialog();
-            if (original == null)
-                return;
-
             IReadOnlyList<IStorageFolder> folders = await _window.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions());
             if (folders.Count == 0)
                 return;
@@ -183,9 +179,9 @@ namespace FusionFall_Mod
 
             try
             {
-                Log("Начало упаковки assets.");
-                await Task.Run(() => RawAssetsHelper.Pack(original, folderPath, output));
-                Log("Упаковка завершена.");
+                Log("Начало сборки assets.");
+                await Task.Run(() => RawAssetsHelper.Pack(folderPath, output));
+                Log("Сборка завершена.");
                 await MessageBoxManager.GetMessageBoxStandard("Success", "Assets packed successfully.").ShowAsync();
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
- replace RawAssetsHelper with wrapper around new v6 packer
- add UnityAssetsV6Packer for unpacking and building assets
- simplify UI assets packing flow

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_6897ca9e83ec8325a7f25fa3d08706a4