### PR TITLE
Improve Unity asset naming with TypeTree data

### DIFF
--- a/FusionFall-Mod/Core/ObjectEntry.cs
+++ b/FusionFall-Mod/Core/ObjectEntry.cs
@@ -9,6 +9,8 @@ namespace FusionFall_Mod.Core
         public uint OffsetRel { get; set; }
         public uint Size { get; set; }
         public int TypeIndex { get; set; }
+        public int? ClassId { get; set; }
+        public int? Flags { get; set; }
     }
 }
 


### PR DESCRIPTION
## Summary
- Preserve class IDs and flags when parsing object table
- Store full TypeTree and extract `m_Name` for file naming
- Sanitize filenames and include type names for clarity

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_6899bdc530308325a40b537901a2a026