### PR TITLE
Wrap DXT5 encoder with lambda

### DIFF
--- a/FusionFall-Mod/ViewModels/MainWindowViewModel.cs
+++ b/FusionFall-Mod/ViewModels/MainWindowViewModel.cs
@@ -332,11 +332,11 @@ namespace FusionFall_Mod.ViewModels
             try
             {
                 Log("Начало сборки BIN.");
-            byte[] templateBytes = await File.ReadAllBytesAsync(templateBinPath);
-            byte[] ttfBytes = await File.ReadAllBytesAsync(inputTtfPath);
-            byte[] result = UnityFontBinFunctions.PackBinFromTtf(templateBytes, ttfBytes, 13, 1024, 432, UnityFontBinFunctions.EncodeDxt5WithNvcompress);
-            await File.WriteAllBytesAsync(outputBinPath, result);
-            Log("Сборка BIN завершена.");
+                byte[] templateBytes = await File.ReadAllBytesAsync(templateBinPath);
+                byte[] ttfBytes = await File.ReadAllBytesAsync(inputTtfPath);
+                byte[] result = UnityFontBinFunctions.PackBinFromTtf(templateBytes, ttfBytes, 13, 1024, 432, (Bitmap atlas) => UnityFontBinFunctions.EncodeDxt5WithNvcompress(atlas));
+                await File.WriteAllBytesAsync(outputBinPath, result);
+                Log("Сборка BIN завершена.");
                 await MessageBoxManager.GetMessageBoxStandard("Success", "BIN packed successfully.").ShowAsync();
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
- Fix `PackBinFromTtf` call by wrapping `EncodeDxt5WithNvcompress` in a lambda matching expected delegate

## Testing
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689a82d83e2c832591327deec9d9cd9d